### PR TITLE
fix: current_timestamp being passed as a string literal instead of raw sql @ kysely seed script.

### DIFF
--- a/storage/postgres-kysely/lib/seed.ts
+++ b/storage/postgres-kysely/lib/seed.ts
@@ -8,7 +8,7 @@ export async function seed() {
     .addColumn('email', 'varchar(255)', (cb) => cb.notNull().unique())
     .addColumn('image', 'varchar(255)')
     .addColumn('createdAt', sql`timestamp with time zone`, (cb) =>
-      cb.defaultTo('CURRENT_TIMESTAMP')
+      cb.defaultTo(sql`CURRENT_TIMESTAMP`)
     )
     .execute()
   console.log(`Created "users" table`)

--- a/storage/postgres-kysely/lib/seed.ts
+++ b/storage/postgres-kysely/lib/seed.ts
@@ -8,7 +8,7 @@ export async function seed() {
     .addColumn('email', 'varchar(255)', (cb) => cb.notNull().unique())
     .addColumn('image', 'varchar(255)')
     .addColumn('createdAt', sql`timestamp with time zone`, (cb) =>
-      cb.defaultTo(sql`CURRENT_TIMESTAMP`)
+      cb.defaultTo(sql`current_timestamp`)
     )
     .execute()
   console.log(`Created "users" table`)


### PR DESCRIPTION
### Description

Kysely seed script is broken because I forgot to wrap `current_timestamp` with sql template tag.

### Demo URL

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
